### PR TITLE
Add icons to highlight role and company in experiences

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.git
+.gitignore
+dist
+Dockerfile
+npm-debug.log
+Dockerfile.*
+.dockerignore
+.vscode
+.idea
+*.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Stage 1: build the React application
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: serve the built assets with nginx
+FROM nginx:1.27-alpine AS runner
+# Remove default nginx website
+RUN rm -rf /usr/share/nginx/html/*
+COPY docker/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,49 @@ This project is built with:
 
 Simply open [Lovable](https://lovable.dev/projects/23b2966e-a83b-49e6-90d0-bb5e2060af82) and click on Share -> Publish.
 
+## Déployer sur votre propre serveur avec Nginx
+
+Si vous souhaitez héberger l’application vous-même sur un serveur où Nginx est déjà installé, voici un guide rapide :
+
+1. **Préparer l’application**
+   - Installez les dépendances : `npm install`
+   - Construisez la version de production : `npm run build`
+   - Le dossier `dist/` généré contient les fichiers statiques à déployer.
+2. **Transférer les fichiers sur le serveur**
+   - Copiez le contenu de `dist/` vers un dossier sur le serveur, par exemple `/var/www/mon-site`.
+   - Assurez-vous que l’utilisateur Nginx peut lire ces fichiers (`chown -R www-data:www-data /var/www/mon-site`).
+3. **Configurer Nginx**
+   - Créez un fichier de configuration, par exemple `/etc/nginx/sites-available/mon-site` :
+
+     ```nginx
+     server {
+       listen 80;
+       server_name exemple.com www.exemple.com;
+
+       root /var/www/mon-site;
+       index index.html;
+
+       location / {
+         try_files $uri $uri/ /index.html;
+       }
+
+       location ~* \.(js|css|png|jpg|jpeg|gif|svg|woff2?)$ {
+         expires 7d;
+         add_header Cache-Control "public";
+       }
+     }
+     ```
+
+   - Activez le site : `ln -s /etc/nginx/sites-available/mon-site /etc/nginx/sites-enabled/`
+   - Vérifiez la configuration : `sudo nginx -t`
+   - Rechargez Nginx : `sudo systemctl reload nginx`
+4. **Sécuriser avec HTTPS (optionnel mais recommandé)**
+   - Installez Certbot : `sudo apt install certbot python3-certbot-nginx`
+   - Générez un certificat : `sudo certbot --nginx -d exemple.com -d www.exemple.com`
+   - Certbot mettra automatiquement à jour la configuration Nginx.
+
+Après ces étapes, votre application Vite sera servie en production via Nginx.
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!
@@ -71,3 +114,17 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/features/custom-domain#custom-domain)
+
+## Construire et lancer avec Docker
+
+Pour exécuter l’application dans un conteneur, assurez-vous d’avoir Docker installé puis suivez ces étapes :
+
+```sh
+# Construire l’image (ajustez le tag selon vos besoins)
+docker build -t mon-portfolio .
+
+# Lancer le conteneur et exposer le port 80 du conteneur sur le port 3000 de l’hôte
+docker run --rm -p 3000:80 mon-portfolio
+```
+
+L’application sera alors accessible sur http://localhost:3000. Le fichier `docker/default.conf` gère la redirection vers `index.html` pour les routes côté client.

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+}

--- a/src/components/portfolio/ContactSection.tsx
+++ b/src/components/portfolio/ContactSection.tsx
@@ -2,8 +2,17 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
+import { Github, Linkedin } from "lucide-react";
 import { contactDetails, siteMeta, socialLinks } from "@/data/portfolio";
+
+const socialIconMap: Record<string, ReactNode> = {
+  github: <Github className="w-6 h-6" aria-hidden="true" />,
+  linkedin: <Linkedin className="w-6 h-6" aria-hidden="true" />
+};
+
+const getSocialIcon = (key: string): ReactNode | undefined =>
+  socialIconMap[key.toLowerCase()];
 
 const ContactSection = () => {
   const [formData, setFormData] = useState({
@@ -83,18 +92,28 @@ const ContactSection = () => {
                     Ajoutez vos réseaux sociaux dans <code>src/data/portfolio.ts</code>.
                   </span>
                 )}
-                {socialLinks.map((social) => (
-                  <a
-                    key={social.label}
-                    href={social.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="w-12 h-12 bg-muted hover:bg-primary/10 rounded-full flex items-center justify-center text-xl transition-all duration-300 hover:scale-110 hover:shadow-lg hover:shadow-primary/25"
-                    aria-label={social.label}
-                  >
-                    {social.icon}
-                  </a>
-                ))}
+                {socialLinks.map((social) => {
+                  const icon =
+                    getSocialIcon(social.icon) ??
+                    getSocialIcon(social.label) ?? (
+                      <span className="text-xl" aria-hidden="true">
+                        {social.icon}
+                      </span>
+                    );
+
+                  return (
+                    <a
+                      key={social.label}
+                      href={social.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="w-12 h-12 bg-muted hover:bg-primary/10 rounded-full flex items-center justify-center transition-all duration-300 hover:scale-110 hover:shadow-lg hover:shadow-primary/25"
+                      aria-label={social.label}
+                    >
+                      {icon}
+                    </a>
+                  );
+                })}
               </div>
             </div>
           </div>

--- a/src/components/portfolio/ExperienceSection.tsx
+++ b/src/components/portfolio/ExperienceSection.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@/components/ui/card";
+import { Briefcase, Building2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import {
   experiences as defaultExperiences,
@@ -72,20 +73,40 @@ const ExperienceSection = () => {
                 {/* Content */}
                 <Card className="flex-1 card-gradient border-border p-6 hover:shadow-lg hover:shadow-primary/10 transition-all duration-300">
                   {exp.image && (
-                    <div className="mb-4 overflow-hidden rounded-lg border border-border/60">
-                      <img
-                        src={exp.image}
-                        alt={`Illustration de ${exp.title}`}
-                        className="w-full max-h-56 object-cover"
-                        loading="lazy"
-                      />
+                    <div className="mb-4 flex justify-start">
+                      <div className="w-32 h-32 overflow-hidden rounded-lg border border-border/60">
+                        <img
+                          src={exp.image}
+                          alt={`Illustration de ${exp.title}`}
+                          className="w-full h-full object-cover"
+                          loading="lazy"
+                        />
+                      </div>
                     </div>
                   )}
 
-                  <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-4">
-                    <div>
-                      <h3 className="text-xl font-semibold text-primary mb-1">{exp.title}</h3>
-                      <p className="text-lg text-accent font-medium">{exp.company}</p>
+                  <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-4 gap-3 md:gap-6">
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-2">
+                        <Briefcase
+                          aria-hidden="true"
+                          className="h-5 w-5 text-primary"
+                          focusable="false"
+                        />
+                        <span className="sr-only">Poste :</span>
+                        <h3 className="text-xl font-semibold text-primary">
+                          {exp.title}
+                        </h3>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Building2
+                          aria-hidden="true"
+                          className="h-5 w-5 text-accent"
+                          focusable="false"
+                        />
+                        <span className="sr-only">Entreprise :</span>
+                        <p className="text-lg text-accent font-medium">{exp.company}</p>
+                      </div>
                     </div>
                     <span className="text-sm text-muted-foreground bg-muted px-3 py-1 rounded-full mt-2 md:mt-0">
                       {exp.period}

--- a/src/components/portfolio/Footer.tsx
+++ b/src/components/portfolio/Footer.tsx
@@ -1,4 +1,5 @@
-import { siteMeta } from "@/data/portfolio";
+import { Button } from "@/components/ui/button";
+import { referentialDownload, siteMeta } from "@/data/portfolio";
 
 const Footer = () => {
   const currentYear = new Date().getFullYear();
@@ -6,7 +7,7 @@ const Footer = () => {
   return (
     <footer className="py-8 border-t border-border bg-card">
       <div className="container mx-auto px-6">
-        <div className="flex flex-col md:flex-row items-center justify-between">
+        <div className="flex flex-col md:flex-row items-center justify-between gap-6">
           <div className="flex items-center gap-2 mb-4 md:mb-0">
             <div className="text-xl font-bold hero-gradient bg-clip-text text-transparent">
               {siteMeta.brand || "Portfolio"}
@@ -15,11 +16,22 @@ const Footer = () => {
             <span className="text-sm text-muted-foreground">{siteMeta.role}</span>
           </div>
 
-          <div className="text-sm text-muted-foreground text-center md:text-right">
-            <p>© {currentYear} {siteMeta.brand || "Portfolio"}. Tous droits réservés.</p>
-            <p className="mt-1">
-              Basé à {siteMeta.location}
-            </p>
+          <div className="flex flex-col items-center md:items-end gap-3 text-sm text-muted-foreground text-center md:text-right">
+            <div>
+              <p>© {currentYear} {siteMeta.brand || "Portfolio"}. Tous droits réservés.</p>
+              <p className="mt-1">
+                Basé à {siteMeta.location}
+              </p>
+            </div>
+            <Button
+              asChild
+              variant="outline"
+              className="w-full md:w-auto border-primary text-primary hover:bg-primary hover:text-white transition-all duration-300"
+            >
+              <a href={referentialDownload.href} download>
+                {referentialDownload.label}
+              </a>
+            </Button>
           </div>
         </div>
       </div>

--- a/src/components/portfolio/HeroSection.tsx
+++ b/src/components/portfolio/HeroSection.tsx
@@ -9,6 +9,13 @@ const scrollToSection = (targetId: string) => {
 };
 
 const HeroSection = () => {
+  const showPrimaryCta =
+    heroContent.primaryCta.label.trim().toLowerCase() !==
+    heroContent.cvDownload.label.trim().toLowerCase();
+  const showSecondaryCta =
+    heroContent.secondaryCta.label.trim().toLowerCase() !==
+    heroContent.cvDownload.label.trim().toLowerCase();
+
   return (
     <section id="accueil" className="min-h-screen flex items-center justify-center section-gradient relative overflow-hidden">
       {/* Background effects */}
@@ -17,7 +24,7 @@ const HeroSection = () => {
         <div className="absolute bottom-1/4 right-1/4 w-48 h-48 bg-accent/20 rounded-full blur-3xl glow-accent"></div>
       </div>
       
-      <div className="container mx-auto px-6 text-center relative z-10">
+      <div className="container mx-auto px-6 text-center relative z-10 pb-24 sm:pb-28">
         <div className="fade-in">
           <h1 className="text-5xl md:text-7xl font-bold mb-4">
             <span className="block text-foreground">{heroContent.intro}</span>
@@ -34,27 +41,40 @@ const HeroSection = () => {
             {heroContent.tagline}
           </p>
 
-          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-10">
             <Button
-              onClick={() => scrollToSection(heroContent.primaryCta.targetId)}
+              asChild
               size="lg"
-              className="hero-gradient text-white hover:shadow-lg hover:shadow-primary/25 transition-all duration-300 px-8 py-6 text-lg font-semibold"
+              className="w-full sm:w-auto hero-gradient text-white hover:shadow-lg hover:shadow-primary/25 transition-all duration-300 px-8 py-6 text-lg font-semibold"
             >
-              {heroContent.primaryCta.label}
+              <a href={heroContent.cvDownload.href} download>
+                {heroContent.cvDownload.label}
+              </a>
             </Button>
-            <Button
-              onClick={() => scrollToSection(heroContent.secondaryCta.targetId)}
-              variant="outline"
-              size="lg"
-              className="border-primary text-primary hover:bg-primary hover:text-white transition-all duration-300 px-8 py-6 text-lg"
-            >
-              {heroContent.secondaryCta.label}
-            </Button>
+            {showPrimaryCta && (
+              <Button
+                onClick={() => scrollToSection(heroContent.primaryCta.targetId)}
+                size="lg"
+                className="w-full sm:w-auto hero-gradient text-white hover:shadow-lg hover:shadow-primary/25 transition-all duration-300 px-8 py-6 text-lg font-semibold"
+              >
+                {heroContent.primaryCta.label}
+              </Button>
+            )}
+            {showSecondaryCta && (
+              <Button
+                onClick={() => scrollToSection(heroContent.secondaryCta.targetId)}
+                variant="outline"
+                size="lg"
+                className="w-full sm:w-auto border-primary text-primary hover:bg-primary hover:text-white transition-all duration-300 px-8 py-6 text-lg"
+              >
+                {heroContent.secondaryCta.label}
+              </Button>
+            )}
           </div>
         </div>
         
         {/* Scroll indicator */}
-        <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
+        <div className="absolute bottom-6 sm:bottom-10 left-1/2 transform -translate-x-1/2 animate-bounce z-20 pointer-events-none">
           <div className="w-6 h-10 border-2 border-primary rounded-full flex justify-center">
             <div className="w-1 h-3 bg-primary rounded-full mt-2 animate-pulse"></div>
           </div>

--- a/src/components/portfolio/Navigation.tsx
+++ b/src/components/portfolio/Navigation.tsx
@@ -5,6 +5,7 @@ import { navigationLinks, siteMeta } from "@/data/portfolio";
 const Navigation = () => {
   const defaultSection = navigationLinks[0]?.id ?? "accueil";
   const [activeSection, setActiveSection] = useState(defaultSection);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -26,6 +27,17 @@ const Navigation = () => {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 768) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   const scrollToSection = (sectionId: string) => {
     const element = document.getElementById(sectionId);
     if (element) {
@@ -36,20 +48,20 @@ const Navigation = () => {
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-md border-b border-border">
       <div className="container mx-auto px-6 py-4">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-4">
           <div className="text-xl font-bold hero-gradient bg-clip-text text-transparent">
             {siteMeta.brand || "Portfolio"}
           </div>
 
-          <div className="hidden md:flex space-x-8">
+          <div className="hidden md:flex flex-wrap justify-end gap-x-6 gap-y-1 text-sm font-medium">
             {navigationLinks.map((item) => (
               <button
                 key={item.id}
                 onClick={() => scrollToSection(item.id)}
                 className={cn(
-                  "relative py-2 px-3 transition-colors duration-300 font-medium",
-                  activeSection === item.id 
-                    ? "text-primary" 
+                  "relative py-2 px-2 transition-colors duration-300",
+                  activeSection === item.id
+                    ? "text-primary"
                     : "text-muted-foreground hover:text-foreground"
                 )}
               >
@@ -63,13 +75,49 @@ const Navigation = () => {
 
           {/* Mobile menu button */}
           <div className="md:hidden">
-            <button className="p-2 text-muted-foreground hover:text-foreground">
+            <button
+              className="p-2 text-muted-foreground hover:text-foreground"
+              onClick={() => setIsMenuOpen((prev) => !prev)}
+              aria-expanded={isMenuOpen}
+              aria-controls="mobile-menu"
+              aria-label={isMenuOpen ? "Fermer le menu" : "Ouvrir le menu"}
+            >
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                {isMenuOpen ? (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                ) : (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                )}
               </svg>
             </button>
           </div>
         </div>
+        {isMenuOpen && (
+          <div
+            id="mobile-menu"
+            className="mt-4 md:hidden rounded-lg border border-border bg-background/95 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80"
+          >
+            <div className="flex flex-col divide-y divide-border">
+              {navigationLinks.map((item) => (
+                <button
+                  key={item.id}
+                  onClick={() => {
+                    scrollToSection(item.id);
+                    setIsMenuOpen(false);
+                  }}
+                  className={cn(
+                    "px-4 py-3 text-left text-sm font-medium transition-colors",
+                    activeSection === item.id
+                      ? "text-primary"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </nav>
   );

--- a/src/components/portfolio/ProjectsSection.tsx
+++ b/src/components/portfolio/ProjectsSection.tsx
@@ -21,6 +21,8 @@ const formatProjectType = (type: Project["type"]) => {
       return "Mobile";
     case "reseaux":
       return "Réseaux";
+    case "cli":
+      return "CLI Python";
     default:
       return "Web";
   }
@@ -52,7 +54,8 @@ const ProjectsSection = () => {
       "web",
       "ia",
       "mobile",
-      "reseaux"
+      "reseaux",
+      "cli"
     ]);
     combinedProjects.forEach((project) => types.add(project.type));
     return Array.from(types);
@@ -123,9 +126,12 @@ const ProjectsSection = () => {
               
               <div className="p-6">
                 {/* Skill highlight badge */}
-                <div className="flex items-center justify-between mb-3">
-                  <span className="px-3 py-1 bg-primary/10 text-primary text-sm rounded-full border border-primary/20 font-medium">
-                    Compétence: {project.skillHighlight}
+                <div className="mb-4">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                    Compétence
+                  </p>
+                  <span className="inline-block px-3 py-1 bg-primary/10 text-primary text-sm rounded-full border border-primary/20 font-medium">
+                    {project.skillHighlight}
                   </span>
                 </div>
                 

--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -13,6 +13,10 @@ export type HeroContent = {
   name: string;
   highlight: string;
   tagline: string;
+  cvDownload: {
+    label: string;
+    href: string;
+  };
   primaryCta: {
     label: string;
     targetId: string;
@@ -51,7 +55,7 @@ export type Project = {
   title: string;
   description: string;
   visual?: string;
-  type: "web" | "ia" | "mobile" | "reseaux";
+  type: "web" | "ia" | "mobile" | "reseaux" | "cli";
   technologies: string[];
   skillHighlight: string;
   github?: string;
@@ -93,8 +97,8 @@ export type SocialLink = {
 };
 
 export const siteMeta = {
-  brand: "Portfolio",
-  role: "Développeur Full Stack",
+  brand: "Noa Morandeau",
+  role: "Alternant Développeur",
   location: "Nouméa, Nouvelle-Calédonie",
   email: "contact@portfolio.dev"
 };
@@ -111,10 +115,14 @@ export const navigationLinks: NavigationLink[] = [
 
 export const heroContent: HeroContent = {
   intro: "Bonjour, je suis",
-  name: "Votre Nom",
-  highlight: "Développeur Full Stack",
+  name: "Noa Morandeau",
+  highlight: "Alternant Développeur",
   tagline:
-    "Je conçois et développe des solutions web modernes. Remplacez ce texte par les informations provenant de votre portfolio.",
+    "Étudiant en BTS SIO option SLAM, je conçois et développe des solutions adaptées aux besoins métiers tout en consolidant mes compétences techniques.",
+  cvDownload: {
+    label: "Télécharger mon CV",
+    href: "/noa-morandeau-cv.pdf"
+  },
   primaryCta: {
     label: "Voir mes projets",
     targetId: "projets"
@@ -123,6 +131,11 @@ export const heroContent: HeroContent = {
     label: "Me contacter",
     targetId: "contact"
   }
+};
+
+export const referentialDownload = {
+  label: "Télécharger le référentiel BTS SIO",
+  href: "/referentiel-bts-sio.pdf"
 };
 
 export const skillCategories: SkillCategory[] = [
@@ -170,11 +183,11 @@ export const skillCategories: SkillCategory[] = [
 export const experiences: Experience[] = [
   {
     id: "default-experience-1",
-    title: "Votre poste",
+    title: "Alternant Développeur",
     company: "Votre entreprise",
     period: "2023 - Aujourd'hui",
     description:
-      "Décrivez votre rôle ici. Remplacez ces informations par celles provenant de votre portfolio.",
+      "En tant qu'alternant développeur en BTS SIO SLAM, je participe à la conception et à la maintenance d'applications tout en approfondissant mes compétences.",
     technologies: ["React", "TypeScript", "Node.js"],
     achievements: [
       "Ajoutez vos réalisations clés.",
@@ -223,8 +236,8 @@ export const contactDetails: ContactDetail[] = [
 ];
 
 export const socialLinks: SocialLink[] = [
-  { icon: "🐙", label: "GitHub", link: "https://github.com" },
-  { icon: "💼", label: "LinkedIn", link: "https://linkedin.com" }
+  { icon: "github", label: "GitHub", link: "https://github.com" },
+  { icon: "linkedin", label: "LinkedIn", link: "https://linkedin.com" }
 ];
 
 export const certifications: Certification[] = [

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -51,7 +51,8 @@ const projectTypeOptions: { value: Project["type"]; label: string }[] = [
   { value: "web", label: "Web" },
   { value: "ia", label: "IA" },
   { value: "mobile", label: "Mobile" },
-  { value: "reseaux", label: "Réseaux" }
+  { value: "reseaux", label: "Réseaux" },
+  { value: "cli", label: "CLI Python" }
 ];
 
 const generateId = (prefix: string) =>


### PR DESCRIPTION
## Summary
- add lucide briefcase and building icons to clearly distinguish job role and company in each experience card
- adjust the header layout to space the new icon labels while keeping the period chip aligned

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5dc7a23188324bfcc3ba2cbe2db31